### PR TITLE
Make wordnet APIs async

### DIFF
--- a/examples/list.js
+++ b/examples/list.js
@@ -1,13 +1,10 @@
-/**
- * WordNet lookup example
- *
- * @author Dariusz Dziuk <me@dariuszdziuk.com>
- */
+const util = require('util');
+const wordnet = require('../lib/wordnet.js');
 
-var wordnet = require('../lib/wordnet.js');
+(async () => {
+  await wordnet.init();
 
-wordnet.list(function(err, list) {
+  let results = await wordnet.list();
 
-  console.log(list);
-
-});
+  console.log(util.inspect(results, false, null, true));
+})();

--- a/examples/list.js
+++ b/examples/list.js
@@ -2,7 +2,7 @@ const util = require('util');
 const wordnet = require('../lib/wordnet.js');
 
 (async () => {
-  await wordnet.init();
+  wordnet.init();
 
   let results = await wordnet.list();
 

--- a/examples/lookup.js
+++ b/examples/lookup.js
@@ -1,4 +1,3 @@
-const util = require('util');
 const program = require('commander');
 const wordnet = require('../lib/wordnet.js');
 

--- a/lib/wordnet.js
+++ b/lib/wordnet.js
@@ -38,7 +38,10 @@ module.exports.init = async function() {
   const extensions = Object.keys(EXTENSIONS_MAP);
 
   // Read data from all index files into memory.
-  await Promise.all(extensions.map(readIndex));
+  // NOTE: We have to run this serially in order to ensure consistent results.
+  await extensions.reduce((p, ext) => {
+    return p.then(() => readIndex(ext));
+  }, Promise.resolve());
 
   // Load the contents from the data files into memory.
   await Promise.all(extensions.map((ext) => {

--- a/lib/wordnet.js
+++ b/lib/wordnet.js
@@ -1,60 +1,17 @@
-/**
- * WordNet Node Wrapper
- *
- * @author Dariusz Dziuk
- */
+let reader = require('./reader');
+let fsp = require('fs').promises;
 
-var reader = require('./reader');
-var async = require('async');
-var fs = require('fs');
+module.exports = {};
 
-/**
- * Public interface
- *
- * @type {Object}
- */
-
-module.exports = {
-
-  /**
-   * Looks up a word
-   *
-   * @param {String} word Word to look up.
-   * @param {Function} callback Std callback with error and definition.
-   */
-
-  lookup: lookup,
-
-  /**
-   * Lists all the words
-   *
-   * @param {Function} callback Std callback with error and list of words.
-   */
-
-  list: list
-
+const SPACE_CHAR = ' ';
+const EXTENSIONS_MAP = {
+  'adj': 'a',
+  'adv': 'r',
+  'noun': 'n',
+  'verb': 'v'
 };
 
-/**
- * List of WordNet db extensions
- *
- * @type {Array}
- */
-
-var _extensions = [
-  'adj',
-  'adv',
-  'noun',
-  'verb'
-];
-
-/**
- * Synset types map
- *
- * @type {Object}
- */
-
-var _synsetTypeMap = {
+const SYNSET_TYPE_MAP = {
   'n': 'noun',
   'v': 'verb',
   'a': 'adjective',
@@ -62,152 +19,70 @@ var _synsetTypeMap = {
   'r': 'adverb'
 };
 
-/**
- * Index lookup
- *
- * @type {Object}
- */
+// These hold the data in memory.
+let _index = {};
+let _data = {};
 
-var _index = {};
-
-/**
- * Open file handlers
- *
- * @type {Object}
- */
-
-var _data = {};
+function toNumber(str, radix = 10) {
+  return parseInt(str, radix);
+}
 
 /**
- * Awaiting callbacks
+ * Gets a key for specified word
  *
- * @type {Array}
+ * @param {String} word Word to build key for.
+ * @return {String} Key for the word.
  */
+function getKey(word) {
+  return '@__' + word;
+}
 
-var _callbacks = [];
 
 /**
- * Is module ready?
+ * Parses the database files and loads them into memory.
  *
- * @type {Boolean}
+ * @return {Promise}
  */
+module.exports.init = function() {
+  const extensions = Object.keys(EXTENSIONS_MAP);
 
-var _isReady = false;
+  // Read data from all index files into memory.
+  return Promise.all(extensions.map(readIndex)).then(() => {
+    // Load the contents from the data files into memory.
+    return Promise.all(extensions.map((ext) => {
+      return readDatabase(ext).then((fileHandle) => _data[EXTENSIONS_MAP[ext]] = fileHandle);
+    }));
+  });
+}
 
 /**
- * Parses an index line
+ * Lists all the words
  *
- * @param {String} line Input line.
- * @param {Function} callback Callback with error and result object.
+ * @return {Array} List of all words.
  */
-
-function parseIndexLine(line, callback) {
-
-  if (line.charAt(0) === ' ') {
-    callback(null, {isComment: true});
-    return;
-  }
-
-  var tokens = line.split(' ');
-  var result = {};
-
-  /* Parse the data */
-  result.lemma = tokens.shift();
-  result.pos = tokens.shift();
-  result.synsetCount = parseInt(tokens.shift(), 10);
-
-  /* Pointers */
-  result.pointerCount = parseInt(tokens.shift(), 10);
-  result.pointers = [];
-  for (var index = 0; index < result.pointerCount; index++) {
-    result.pointers.push(tokens.shift());
-  }
-
-  result.senseCount = parseInt(tokens.shift(), 10);
-  result.tagSenseCount = parseInt(tokens.shift(), 10);
-  result.synsetOffset = parseInt(tokens.shift(), 10);
-
-  callback(null, result);
-
-};
+module.exports.list = function() {
+  return Object.keys(_index).map(function(key) {
+    return key.substring(3).replace(/_/g, SPACE_CHAR);
+  });
+}
 
 /**
- * Parses a data file line
+ * Looks up a word
  *
- * @param {String} line Data line to parse.
- * @param {Boolean} pointers Should parse the pointers as well?
- * @param {Function} callback Std callback with error and parsed object.
+ * @param {String} word Word to look up.
+ * @param {Function} callback Standard callback with error and result.
  */
+module.exports.lookup = function(word) {
+  let key = getKey(word.replace(new RegExp(SPACE_CHAR, 'g'), '_'));
+  let definitions = _index[key];
 
-function parseDataLine(line, pointers, callback) {
-
-  /* Split the glossary */
-  var parts = line.split('|');
-  var metadata = parts[0].split(' ');
-  var glossary = parts[1] ? parts[1].trim() : '';
-
-  /* Parse the metadata */
-  var meta = {};
-  meta.synsetOffset = parseInt(metadata.shift(), 10);
-  meta.lexFilenum = parseInt(metadata.shift(), 10);
-  meta.synsetType = _synsetTypeMap[metadata.shift()];
-  meta.wordCount = parseInt(metadata.shift(), 16);
-  meta.words = [];
-
-  /* Parse the words */
-  for (var wordIdx = 0; wordIdx < meta.wordCount; wordIdx++) {
-    meta.words.push({
-      word: metadata.shift(),
-      lexId: parseInt(metadata.shift(), 16)
-    });
-  }
-
-  /* Parse the pointers */
-  meta.pointerCount = parseInt(metadata.shift(), 10);
-  meta.pointers = [];
-  for (var pointerIdx = 0; pointerIdx < meta.pointerCount; pointerIdx++) {
-    meta.pointers.push({
-      pointerSymbol: metadata.shift(),
-      synsetOffset: parseInt(metadata.shift(), 10),
-      pos: metadata.shift(),
-      sourceTargetHex: metadata.shift()
-    });
-  }
-
-  /* Skip the pointers data */
-  if (!pointers) {
-    callback(null, {
-      meta: meta,
-      glossary: glossary
-    });
-    return;
-  }
-
-  /* Parse the pointers data */
-  async.each(meta.pointers, function(pointer, callback) {
-
-    readData(pointer, false, function(err, data) {
-      pointer.data = data;
-      callback();
-    });
-
-  },
-  function(err) {
-
-    /* Handle error */
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    callback(null, {
-      meta: meta,
-      glossary: glossary
-    });
-
+  let promises = definitions.map((defintion) => {
+    return readData(defintion, false);
   });
 
-};
+  return Promise.all(promises);
+}
+
 
 /**
  * Reads the data for specified synctactic category
@@ -216,189 +91,153 @@ function parseDataLine(line, pointers, callback) {
  * @param {Boolean} pointers Should parse pointers?
  * @param {Function} callback Std callback with error and parsed result object.
  */
-
-function readData(definition, pointers, callback) {
-
-  var pos = definition.pos;
-  var offset = definition.synsetOffset;
+function readData(definition, skipPointers) {
+  let { pos, synsetOffset } = definition;
 
   if (!pos) {
-    callback(null, {});
-    return;
+    return Promise.resolve();
   }
 
-  /* Read from file */
-  var fd = _data[pos];
-  var buffer = new Buffer(1024);
-  fs.read(fd, buffer, 0, 1024, offset, function(err, bytesRead, buffer) {
+  // Read from currently open file.
+  let fileHandle = _data[pos];
+  let buffer = Buffer.alloc(1024);
 
-    var line = buffer.toString().split('\n')[0];
-    parseDataLine(line, pointers, callback);
-
+  return fileHandle.read(buffer, 0, 1024, synsetOffset).then(({ bytesRead, buffer }) => {
+    let line = buffer.toString().split('\n')[0];
+    return parseDataLine(line, skipPointers);
   });
+}
 
-};
+function readIndex(extension) {
+  return new Promise((resolve) => {
+    reader.read(__dirname + '/../db/index.' + extension, (line) => {
+      let result = parseIndexLine(line);
 
-/**
- * Gets a key for specified word
- *
- * @param {String} word Word to build key for.
- * @return {String} Key for the word.
- */
-
-function getKey(word) {
-
-  return '@__' + word;
-
-};
-
-/**
- * Looks up a word
- *
- * @param {String} word Word to look up.
- * @param {Function} callback Standard callback with error and result.
- */
-
-function lookup(word, callback) {
-
-  onReady(function() {
-
-    var key = getKey(word.replace(/ /g, '_'));
-    var definitions = _index[key];
-
-    if (!definitions) {
-      callback(new Error('Definition(s) not found.'));
-      return;
-    }
-
-    var results = [];
-
-    async.eachSeries(definitions, function(defintion, callback) {
-
-      /* Read the word data */
-      readData(defintion, true, function(err, result) {
-
-        if (err) {
-          callback(err);
-          return;
-        }
-
-        results.push(result);
-        callback();
-
-      });
-
-    }, function(err) {
-
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      callback(null, results);
-
-    });
-
-  });
-
-};
-
-/**
- * Reads a WordNet database
- *
- * @param {String} extension WordNet DB extension.
- * @param {Function} callback Standard callback with error and index array.
- */
-
-function readDatabase(extension, callback) {
-
-  reader.read(__dirname + '/../db/index.' + extension, function(line) {
-
-    parseIndexLine(line, function(err, result) {
       if (!result.isComment) {
-        /* Prefix not to break any built-in properties */
-        var key = getKey(result.lemma);
+        // Prefix not to break any built-in properties.
+        let key = getKey(result.lemma);
         if (!_index[key]) {
           _index[key] = [];
         }
         _index[key].push(result);
       }
-    });
-
-  }, function() {
-    callback();
-  });
-
-};
-
-/**
- * Lists all the words
- *
- * @param {Function} callback Std callback with error and list of words.
- */
-
-function list(callback) {
-
-  onReady(function() {
-
-    var list = [];
-    Object.keys(_index).forEach(function(key) {
-      list.push(key.substring(3).replace(/_/g, ' '));
-    });
-
-    callback(null, list);
-
-  });
-
-}
-
-/**
- * Waits till the dictionary is loaded
- *
- * @param {Function} callback Callback to be called when ready.
- */
-
-function onReady(callback) {
-
-  if (!_isReady) {
-    _callbacks.push(callback);
-  }
-  else {
-    callback();
-  }
-
-};
-
-/**
- * Initializes the module after preparing the dictionary
- */
-
-function init() {
-
-  _isReady = true;
-  _callbacks.forEach(function(callback) {
-    callback();
+    }, resolve);
   })
-
 }
 
-/* Read all files */
-async.eachSeries(_extensions, readDatabase, function(err) {
+/**
+ * Reads a WordNet database
+ *
+ * @param {String} extension WordNet DB extension.
+ * @return {Promise}
+ */
+function readDatabase(extension) {
+  return fsp.open(__dirname + '/../db/data.' + extension, 'r');
+}
 
-  /* Extension to pos value mapper */
-  var extensionToPos = {
-    'adj': 'a',
-    'adv': 'r',
-    'noun': 'n',
-    'verb': 'v'
+/**
+ * Parses an index line
+ *
+ * @param {String} line Input line.
+ * @return {Object} Attributes of the parsed line.
+ */
+function parseIndexLine(line) {
+  // Documentation for index lines at https://wordnet.princeton.edu/documentation/wndb5wn
+  // lemma  pos  synset_cnt  p_cnt  [ptr_symbol...]  sense_cnt  tagsense_cnt   synset_offset  [synset_offset...]
+
+  // Ignore comments.
+  if (line.charAt(0) === SPACE_CHAR) {
+    return { isComment: true };
+  }
+
+  let result = {};
+  let [ lemma, pos, synsetCount, ...parts ] = line.split(SPACE_CHAR);
+  let pointerCount = toNumber(parts.shift());
+
+  // Iterate through the pointers.
+  let pointers = [];
+  for (let index = 0; index < pointerCount; index++) {
+    pointers.push(parts.shift());
+  }
+
+  // Extract remaining values.
+  let [ senseCount, tagSenseCount, synsetOffset, ...additionalSynsetOffsets] = parts;
+
+  return {
+    lemma,
+    pos,
+    synsetCount: toNumber(synsetCount),
+    pointerCount,
+    pointers,
+    senseCount: toNumber(senseCount),
+    tagSenseCount: toNumber(tagSenseCount),
+    synsetOffset: toNumber(synsetOffset)
+  }
+}
+
+/**
+ * Parses a data file line
+ *
+ * @param {String} line Data line to parse.
+ * @param {Boolean} pointers Should parse the pointers as well?
+ * @param {Function} callback Std callback with error and parsed object.
+ */
+async function parseDataLine(line, skipPointers) {
+  // Documentation for data lines at https://wordnet.princeton.edu/documentation/wndb5wn
+  // synset_offset  lex_filenum  ss_type  w_cnt  word  lex_id  [word  lex_id...]  p_cnt  [ptr...]  [frames...]  |   gloss
+
+  // Separate metadata from glossary.
+  let metaAndGlossary = line.split('|');
+  let metadata = metaAndGlossary[0].split(' ');
+  let glossary = metaAndGlossary[1] ? metaAndGlossary[1].trim() : '';
+
+  // Extract the metadata.
+  let [ synsetOffset, lexFilenum, synsetType, ...parts ] = metadata;
+
+  // Extract the words.
+  let wordCount = toNumber(parts.shift(), 16);
+  let words = [];
+  for (let wordIdx = 0; wordIdx < wordCount; wordIdx++) {
+    words.push({
+      word: parts.shift(),
+      lexId: toNumber(parts.shift(), 16)
+    });
+  }
+
+  // Extract the pointers.
+  let pointerCount = toNumber(parts.shift());
+  let pointers = [];
+  for (let pointerIdx = 0; pointerIdx < pointerCount; pointerIdx++) {
+    pointers.push({
+      pointerSymbol: parts.shift(),
+      synsetOffset: parseInt(parts.shift(), 10),
+      pos: parts.shift(),
+      sourceTargetHex: parts.shift()
+    });
+  }
+
+  if (!skipPointers) {
+    // Get the data for each pointer.
+    let pointersData = await Promise.all(pointers.map((pointer) => {
+      // Don't recurse further than one degree.
+      return readData(pointer, true);
+    }));
+    // NOTE: this mutates the pointer objects.
+    pointersData.forEach((data, index) => {
+      pointers[index].data = data;
+    });
+  }
+
+  return {
+    glossary,
+    meta: {
+      synsetOffset: toNumber(synsetOffset),
+      lexFilenum: toNumber(lexFilenum),
+      synsetType: SYNSET_TYPE_MAP[synsetType],
+      wordCount,
+      words,
+      pointerCount,
+      pointers
+    }
   };
-
-  /* Open file handlers */
-  _extensions.forEach(function(extension) {
-    _data[extensionToPos[extension]] = fs.openSync(__dirname + '/../db/data.' + extension, 'r');
-  });
-
-  /* Init */
-  init();
-
-});
+}

--- a/lib/wordnet.js
+++ b/lib/wordnet.js
@@ -4,6 +4,7 @@ let fsp = require('fs').promises;
 module.exports = {};
 
 const SPACE_CHAR = ' ';
+const KEY_PREFIX = '@__';
 const EXTENSIONS_MAP = {
   'adj': 'a',
   'adv': 'r',
@@ -25,7 +26,7 @@ let _data = {};
 
 // Utilities.
 function toNumber(str, radix = 10) { return parseInt(str, radix) }
-function getKey(word) { return `@__${word}` }
+function getKey(word) { return `${KEY_PREFIX}${word}` }
 
 
 /**
@@ -54,7 +55,7 @@ module.exports.init = async function() {
  */
 module.exports.list = function() {
   return Object.keys(_index).map(function(key) {
-    return key.substring(3).replace(/_/g, SPACE_CHAR);
+    return key.substring(KEY_PREFIX.length).replace(/_/g, SPACE_CHAR);
   });
 }
 

--- a/lib/wordnet.js
+++ b/lib/wordnet.js
@@ -23,40 +23,32 @@ const SYNSET_TYPE_MAP = {
 let _index = {};
 let _data = {};
 
-function toNumber(str, radix = 10) {
-  return parseInt(str, radix);
-}
-
-/**
- * Gets a key for specified word
- *
- * @param {String} word Word to build key for.
- * @return {String} Key for the word.
- */
-function getKey(word) {
-  return '@__' + word;
-}
+// Utilities.
+function toNumber(str, radix = 10) { return parseInt(str, radix) }
+function getKey(word) { return `@__${word}` }
 
 
 /**
  * Parses the database files and loads them into memory.
  *
- * @return {Promise}
+ * @return {Promise} Empty promise object.
  */
-module.exports.init = function() {
+module.exports.init = async function() {
   const extensions = Object.keys(EXTENSIONS_MAP);
 
   // Read data from all index files into memory.
-  return Promise.all(extensions.map(readIndex)).then(() => {
-    // Load the contents from the data files into memory.
-    return Promise.all(extensions.map((ext) => {
-      return readDatabase(ext).then((fileHandle) => _data[EXTENSIONS_MAP[ext]] = fileHandle);
-    }));
-  });
+  await Promise.all(extensions.map(readIndex));
+
+  // Load the contents from the data files into memory.
+  await Promise.all(extensions.map((ext) => {
+    return readDatabase(ext).then((fileHandle) => _data[EXTENSIONS_MAP[ext]] = fileHandle);
+  }));
+
+  return Promise.resolve();
 }
 
 /**
- * Lists all the words
+ * Lists all the words.
  *
  * @return {Array} List of all words.
  */
@@ -67,14 +59,18 @@ module.exports.list = function() {
 }
 
 /**
- * Looks up a word
+ * Looks up a word.
  *
- * @param {String} word Word to look up.
- * @param {Function} callback Standard callback with error and result.
+ * @param {String} word Word to search.
+ * @return {Promise} Resolves with definitions for the given word.
  */
 module.exports.lookup = function(word) {
   let key = getKey(word.replace(new RegExp(SPACE_CHAR, 'g'), '_'));
   let definitions = _index[key];
+
+  if (!definitions) {
+    return Promise.reject(new Error(`No definition(s) found for "${word}.`))
+  }
 
   let promises = definitions.map((defintion) => {
     return readData(defintion, false);
@@ -85,11 +81,10 @@ module.exports.lookup = function(word) {
 
 
 /**
- * Reads the data for specified synctactic category
+ * Reads the data for specified synctactic category.
  *
  * @param {Object} definition Index definition of the word.
- * @param {Boolean} pointers Should parse pointers?
- * @param {Function} callback Std callback with error and parsed result object.
+ * @param {Boolean} skipPointers Whether to skip inclusion of pointer data.
  */
 function readData(definition, skipPointers) {
   let { pos, synsetOffset } = definition;
@@ -126,19 +121,19 @@ function readIndex(extension) {
 }
 
 /**
- * Reads a WordNet database
+ * Reads a WordNet database.
  *
  * @param {String} extension WordNet DB extension.
- * @return {Promise}
+ * @return {Promise} Resolves with FileHandle object.
  */
 function readDatabase(extension) {
   return fsp.open(__dirname + '/../db/data.' + extension, 'r');
 }
 
 /**
- * Parses an index line
+ * Parses an index line.
  *
- * @param {String} line Input line.
+ * @param {String} line Index line to parse.
  * @return {Object} Attributes of the parsed line.
  */
 function parseIndexLine(line) {
@@ -176,11 +171,11 @@ function parseIndexLine(line) {
 }
 
 /**
- * Parses a data file line
+ * Parses a data file line.
  *
  * @param {String} line Data line to parse.
- * @param {Boolean} pointers Should parse the pointers as well?
- * @param {Function} callback Std callback with error and parsed object.
+ * @param {Boolean} skipPointers Whether to skip inclusion of pointer data.
+ * @return {Object} Attributes of the parsed line.
  */
 async function parseDataLine(line, skipPointers) {
   // Documentation for data lines at https://wordnet.princeton.edu/documentation/wndb5wn

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "version": "0.1.2",
   "author": "Dariusz Dziuk <me@dariuszdziuk.com>",
   "main": "./lib/wordnet.js",
-  "dependencies": {
-    "async": "~0.2.9"
-  },
+  "dependencies": {},
   "devDependencies": {
-    "commander": "~2.0.0"
+    "commander": "^5.1.0",
+    "nyc": "^15.1.0",
+    "tape": "^5.0.1",
+    "xo": "^0.32.0"
   },
   "keywords": [
     "wordnet",

--- a/test/fixture.json
+++ b/test/fixture.json
@@ -1,0 +1,1526 @@
+{
+  "test": [{
+    "glossary": "put to the test, as for its quality, or give experimental use to; \"This approach has been tried with good results\"; \"Test this recipe\"",
+    "meta": {
+      "synsetOffset": 2531625,
+      "lexFilenum": 41,
+      "synsetType": "verb",
+      "wordCount": 6,
+      "words": [
+        { "word": "test", "lexId": 0 },
+        { "word": "prove", "lexId": 3 },
+        { "word": "try", "lexId": 1 },
+        { "word": "try_out", "lexId": 0 },
+        { "word": "examine", "lexId": 0 },
+        { "word": "essay", "lexId": 1 }
+      ],
+      "pointerCount": 13,
+      "pointers": [
+        {
+          "pointerSymbol": "@",
+          "synsetOffset": 670261,
+          "pos": "v",
+          "sourceTargetHex": "0000",
+          "data": {
+            "glossary": "form a critical opinion of; \"I cannot judge some works of modern art\"; \"How do you evaluate this grant proposal?\" \"We shouldn't pass judgment on other people\"",
+            "meta": {
+              "synsetOffset": 670261,
+              "lexFilenum": 31,
+              "synsetType": "verb",
+              "wordCount": 3,
+              "words": [
+                { "word": "evaluate", "lexId": 1 },
+                { "word": "pass_judgment", "lexId": 0 },
+                { "word": "judge", "lexId": 0 }
+              ],
+              "pointerCount": 26,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 628491,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10066732,
+                  "pos": "n",
+                  "sourceTargetHex": "0302"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 874067,
+                  "pos": "n",
+                  "sourceTargetHex": "0301"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5789432,
+                  "pos": "n",
+                  "sourceTargetHex": "0303"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 649892,
+                  "pos": "a",
+                  "sourceTargetHex": "0102"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 658052,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 670991,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 673983,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 674340,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 679937,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 681281,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 681429,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 682592,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 685683,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 686447,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 689344,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 712135,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 719734,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 726300,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 740053,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 807178,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 822367,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 855512,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2523784,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2523953,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 7197021,
+          "pos": "n",
+          "sourceTargetHex": "0501",
+          "data": {
+            "glossary": "a set of questions or exercises evaluating skill or knowledge; \"when the test was stolen the professor had to make a new set of questions\"",
+            "meta": {
+              "synsetOffset": 7197021,
+              "lexFilenum": 10,
+              "synsetType": "noun",
+              "wordCount": 3,
+              "words": [
+                { "word": "examination", "lexId": 0 },
+                { "word": "exam", "lexId": 0 },
+                { "word": "test", "lexId": 0 }
+              ],
+              "pointerCount": 18,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 6252138,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 669970,
+                  "pos": "v",
+                  "sourceTargetHex": "0301"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 1112584,
+                  "pos": "v",
+                  "sourceTargetHex": "0301"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 786458,
+                  "pos": "v",
+                  "sourceTargetHex": "0302"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0105"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 788564,
+                  "pos": "v",
+                  "sourceTargetHex": "0102"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 786816,
+                  "pos": "v",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 7197537,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 7197889,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 7198119,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 7198276,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 7198437,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 7198605,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 7198846,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 7199013,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 7199191,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 7199328,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 7199456,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 5787005,
+          "pos": "n",
+          "sourceTargetHex": "0502",
+          "data": {
+            "glossary": "a detailed inspection of your conscience (as done daily by Jesuits)",
+            "meta": {
+              "synsetOffset": 5787005,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 2,
+              "words": [
+                { "word": "examen", "lexId": 0 },
+                { "word": "examination", "lexId": 3 }
+              ],
+              "pointerCount": 3,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5786655,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0205"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 644583,
+                  "pos": "v",
+                  "sourceTargetHex": "0204"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 636461,
+          "pos": "n",
+          "sourceTargetHex": "0501",
+          "data": {
+            "glossary": "the act of giving students or candidates a test (as by questions) to determine what they know or have learned",
+            "meta": {
+              "synsetOffset": 636461,
+              "lexFilenum": 4,
+              "synsetType": "noun",
+              "wordCount": 2,
+              "words": [
+                { "word": "examination", "lexId": 2 },
+                { "word": "testing", "lexId": 2 }
+              ],
+              "pointerCount": 6,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 633864,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 786458,
+                  "pos": "v",
+                  "sourceTargetHex": "0202"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0105"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 788564,
+                  "pos": "v",
+                  "sourceTargetHex": "0102"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 786816,
+                  "pos": "v",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 637145,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 10068234,
+          "pos": "n",
+          "sourceTargetHex": "0501",
+          "data": {
+            "glossary": "someone who administers a test to determine your qualifications",
+            "meta": {
+              "synsetOffset": 10068234,
+              "lexFilenum": 18,
+              "synsetType": "noun",
+              "wordCount": 3,
+              "words": [
+                { "word": "examiner", "lexId": 1 },
+                { "word": "tester", "lexId": 0 },
+                { "word": "quizzer", "lexId": 0 }
+              ],
+              "pointerCount": 4,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 10207831,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 786458,
+                  "pos": "v",
+                  "sourceTargetHex": "0301"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 786458,
+                  "pos": "v",
+                  "sourceTargetHex": "0202"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0105"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 5799212,
+          "pos": "n",
+          "sourceTargetHex": "0404",
+          "data": {
+            "glossary": "trying something to find out about it; \"a sample for ten days free trial\"; \"a trial of progesterone failed to relieve the pain\"",
+            "meta": {
+              "synsetOffset": 5799212,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 4,
+              "words": [
+                { "word": "trial", "lexId": 0 },
+                { "word": "trial_run", "lexId": 0 },
+                { "word": "test", "lexId": 2 },
+                { "word": "tryout", "lexId": 0 }
+              ],
+              "pointerCount": 10,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5798043,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0404"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 1195299,
+                  "pos": "v",
+                  "sourceTargetHex": "0403"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0301"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 1195299,
+                  "pos": "v",
+                  "sourceTargetHex": "0102"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5799581,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5799761,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5799952,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5800153,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5800527,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 10728998,
+          "pos": "n",
+          "sourceTargetHex": "0301",
+          "data": {
+            "glossary": "one who tries",
+            "meta": {
+              "synsetOffset": 10728998,
+              "lexFilenum": 18,
+              "synsetType": "noun",
+              "wordCount": 3,
+              "words": [
+                { "word": "trier", "lexId": 1 },
+                { "word": "attempter", "lexId": 0 },
+                { "word": "essayer", "lexId": 0 }
+              ],
+              "pointerCount": 6,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 7846,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2530167,
+                  "pos": "v",
+                  "sourceTargetHex": "0304"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2530167,
+                  "pos": "v",
+                  "sourceTargetHex": "0203"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0103"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2530167,
+                  "pos": "v",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 1195299,
+                  "pos": "v",
+                  "sourceTargetHex": "0102"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 794367,
+          "pos": "n",
+          "sourceTargetHex": "0302",
+          "data": {
+            "glossary": "the act of undergoing testing; \"he survived the great test of battle\"; \"candidates must compete in a trial of skill\"",
+            "meta": {
+              "synsetOffset": 794367,
+              "lexFilenum": 4,
+              "synsetType": "noun",
+              "wordCount": 2,
+              "words": [ { "word": "test", "lexId": 3 }, { "word": "trial", "lexId": 3 } ],
+              "pointerCount": 5,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 786195,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0203"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 669970,
+                  "pos": "v",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 1112584,
+                  "pos": "v",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 786458,
+                  "pos": "v",
+                  "sourceTargetHex": "0102"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 5799212,
+          "pos": "n",
+          "sourceTargetHex": "0103",
+          "data": {
+            "glossary": "trying something to find out about it; \"a sample for ten days free trial\"; \"a trial of progesterone failed to relieve the pain\"",
+            "meta": {
+              "synsetOffset": 5799212,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 4,
+              "words": [
+                { "word": "trial", "lexId": 0 },
+                { "word": "trial_run", "lexId": 0 },
+                { "word": "test", "lexId": 2 },
+                { "word": "tryout", "lexId": 0 }
+              ],
+              "pointerCount": 10,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5798043,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0404"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 1195299,
+                  "pos": "v",
+                  "sourceTargetHex": "0403"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0301"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 1195299,
+                  "pos": "v",
+                  "sourceTargetHex": "0102"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5799581,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5799761,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5799952,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5800153,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5800527,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 639975,
+          "pos": "n",
+          "sourceTargetHex": "0101",
+          "data": {
+            "glossary": "the act of subjecting to experimental test in order to determine how well something works; \"they agreed to end the testing of atomic weapons\"",
+            "meta": {
+              "synsetOffset": 639975,
+              "lexFilenum": 4,
+              "synsetType": "noun",
+              "wordCount": 1,
+              "words": [ { "word": "testing", "lexId": 0 } ],
+              "pointerCount": 2,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 639556,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0101"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 2520997,
+          "pos": "v",
+          "sourceTargetHex": "0000",
+          "data": {
+            "glossary": "check or regulate (a scientific experiment) by conducting a parallel experiment or comparing with another standard; \"Are you controlling for the temperature?\"",
+            "meta": {
+              "synsetOffset": 2520997,
+              "lexFilenum": 41,
+              "synsetType": "verb",
+              "wordCount": 2,
+              "words": [
+                { "word": "control", "lexId": 2 },
+                { "word": "verify", "lexId": 0 }
+              ],
+              "pointerCount": 4,
+              "pointers": [
+                {
+                  "pointerSymbol": "$",
+                  "synsetOffset": 662589,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": ";c",
+                  "synsetOffset": 5999797,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5798569,
+                  "pos": "n",
+                  "sourceTargetHex": "0102"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 2532079,
+          "pos": "v",
+          "sourceTargetHex": "0000",
+          "data": {
+            "glossary": "circulate or discuss tentatively; test the waters with; \"The Republicans are floating the idea of a tax reform\"",
+            "meta": {
+              "synsetOffset": 2532079,
+              "lexFilenum": 41,
+              "synsetType": "verb",
+              "wordCount": 1,
+              "words": [ { "word": "float", "lexId": 3 } ],
+              "pointerCount": 1,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 2532261,
+          "pos": "v",
+          "sourceTargetHex": "0000",
+          "data": {
+            "glossary": "test something under the conditions under which it will actually be used; \"The Army field tested the new tanks\"",
+            "meta": {
+              "synsetOffset": 2532261,
+              "lexFilenum": 41,
+              "synsetType": "verb",
+              "wordCount": 1,
+              "words": [ { "word": "field-test", "lexId": 0 } ],
+              "pointerCount": 2,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 2531625,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799581,
+                  "pos": "n",
+                  "sourceTargetHex": "0102"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "glossary": "trying something to find out about it; \"a sample for ten days free trial\"; \"a trial of progesterone failed to relieve the pain\"",
+    "meta": {
+      "synsetOffset": 5799212,
+      "lexFilenum": 9,
+      "synsetType": "noun",
+      "wordCount": 4,
+      "words": [
+        { "word": "trial", "lexId": 0 },
+        { "word": "trial_run", "lexId": 0 },
+        { "word": "test", "lexId": 2 },
+        { "word": "tryout", "lexId": 0 }
+      ],
+      "pointerCount": 10,
+      "pointers": [
+        {
+          "pointerSymbol": "@",
+          "synsetOffset": 5798043,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "glossary": "the testing of an idea; \"it was an experiment in living\"; \"not all experimentation is done in laboratories\"",
+            "meta": {
+              "synsetOffset": 5798043,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 2,
+              "words": [
+                { "word": "experiment", "lexId": 0 },
+                { "word": "experimentation", "lexId": 0 }
+              ],
+              "pointerCount": 6,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5797597,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2532886,
+                  "pos": "v",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2532595,
+                  "pos": "v",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2532595,
+                  "pos": "v",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5799071,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 2531625,
+          "pos": "v",
+          "sourceTargetHex": "0404",
+          "data": {
+            "glossary": "put to the test, as for its quality, or give experimental use to; \"This approach has been tried with good results\"; \"Test this recipe\"",
+            "meta": {
+              "synsetOffset": 2531625,
+              "lexFilenum": 41,
+              "synsetType": "verb",
+              "wordCount": 6,
+              "words": [
+                { "word": "test", "lexId": 0 },
+                { "word": "prove", "lexId": 3 },
+                { "word": "try", "lexId": 1 },
+                { "word": "try_out", "lexId": 0 },
+                { "word": "examine", "lexId": 0 },
+                { "word": "essay", "lexId": 1 }
+              ],
+              "pointerCount": 13,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 670261,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 7197021,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5787005,
+                  "pos": "n",
+                  "sourceTargetHex": "0502"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 636461,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10068234,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0404"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10728998,
+                  "pos": "n",
+                  "sourceTargetHex": "0301"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 794367,
+                  "pos": "n",
+                  "sourceTargetHex": "0302"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0103"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 639975,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2520997,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2532079,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2532261,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 1195299,
+          "pos": "v",
+          "sourceTargetHex": "0403",
+          "data": {
+            "glossary": "take a sample of; \"Try these new crackers\"; \"Sample the regional dishes\"",
+            "meta": {
+              "synsetOffset": 1195299,
+              "lexFilenum": 34,
+              "synsetType": "verb",
+              "wordCount": 4,
+              "words": [
+                { "word": "sample", "lexId": 0 },
+                { "word": "try", "lexId": 0 },
+                { "word": "try_out", "lexId": 0 },
+                { "word": "taste", "lexId": 0 }
+              ],
+              "pointerCount": 13,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 1156834,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 7578879,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10692482,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5822612,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 841901,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0304"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10728998,
+                  "pos": "n",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5821775,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10692482,
+                  "pos": "n",
+                  "sourceTargetHex": "0104"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 8463817,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 4133211,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 1195675,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 2531625,
+          "pos": "v",
+          "sourceTargetHex": "0301",
+          "data": {
+            "glossary": "put to the test, as for its quality, or give experimental use to; \"This approach has been tried with good results\"; \"Test this recipe\"",
+            "meta": {
+              "synsetOffset": 2531625,
+              "lexFilenum": 41,
+              "synsetType": "verb",
+              "wordCount": 6,
+              "words": [
+                { "word": "test", "lexId": 0 },
+                { "word": "prove", "lexId": 3 },
+                { "word": "try", "lexId": 1 },
+                { "word": "try_out", "lexId": 0 },
+                { "word": "examine", "lexId": 0 },
+                { "word": "essay", "lexId": 1 }
+              ],
+              "pointerCount": 13,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 670261,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 7197021,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5787005,
+                  "pos": "n",
+                  "sourceTargetHex": "0502"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 636461,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10068234,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0404"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10728998,
+                  "pos": "n",
+                  "sourceTargetHex": "0301"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 794367,
+                  "pos": "n",
+                  "sourceTargetHex": "0302"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0103"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 639975,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2520997,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2532079,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2532261,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 1195299,
+          "pos": "v",
+          "sourceTargetHex": "0102",
+          "data": {
+            "glossary": "take a sample of; \"Try these new crackers\"; \"Sample the regional dishes\"",
+            "meta": {
+              "synsetOffset": 1195299,
+              "lexFilenum": 34,
+              "synsetType": "verb",
+              "wordCount": 4,
+              "words": [
+                { "word": "sample", "lexId": 0 },
+                { "word": "try", "lexId": 0 },
+                { "word": "try_out", "lexId": 0 },
+                { "word": "taste", "lexId": 0 }
+              ],
+              "pointerCount": 13,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 1156834,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 7578879,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10692482,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5822612,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 841901,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0304"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10728998,
+                  "pos": "n",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5821775,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10692482,
+                  "pos": "n",
+                  "sourceTargetHex": "0104"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 8463817,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 4133211,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 1195675,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 5799581,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "glossary": "a test of the performance of some new product under the conditions in which it will be used",
+            "meta": {
+              "synsetOffset": 5799581,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 2,
+              "words": [
+                { "word": "field_trial", "lexId": 0 },
+                { "word": "field_test", "lexId": 0 }
+              ],
+              "pointerCount": 2,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2532261,
+                  "pos": "v",
+                  "sourceTargetHex": "0201"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 5799761,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "glossary": "(computer science) a first test of an experimental product (such as computer software) carried out by the developer",
+            "meta": {
+              "synsetOffset": 5799761,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 1,
+              "words": [ { "word": "alpha_test", "lexId": 0 } ],
+              "pointerCount": 2,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": ";c",
+                  "synsetOffset": 3082979,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 5799952,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "glossary": "(computer science) a second test of an experimental product (such as computer software) carried out by an outside organization",
+            "meta": {
+              "synsetOffset": 5799952,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 1,
+              "words": [ { "word": "beta_test", "lexId": 0 } ],
+              "pointerCount": 2,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": ";c",
+                  "synsetOffset": 3082979,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 5800153,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "glossary": "a test to insure that a vehicle is roadworthy",
+            "meta": {
+              "synsetOffset": 5800153,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 1,
+              "words": [ { "word": "road_test", "lexId": 0 } ],
+              "pointerCount": 2,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5800387,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 5800527,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "glossary": "a test of public opinion",
+            "meta": {
+              "synsetOffset": 5800527,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 1,
+              "words": [ { "word": "trial_balloon", "lexId": 0 } ],
+              "pointerCount": 1,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  }]
+}

--- a/test/fixture.json
+++ b/test/fixture.json
@@ -1,6 +1,645 @@
 {
   "test": [{
-    "glossary": "put to the test, as for its quality, or give experimental use to; \"This approach has been tried with good results\"; \"Test this recipe\"",
+    "meta": {
+      "synsetOffset": 5799212,
+      "lexFilenum": 9,
+      "synsetType": "noun",
+      "wordCount": 4,
+      "words": [
+        { "word": "trial", "lexId": 0 },
+        { "word": "trial_run", "lexId": 0 },
+        { "word": "test", "lexId": 2 },
+        { "word": "tryout", "lexId": 0 }
+      ],
+      "pointerCount": 10,
+      "pointers": [
+        {
+          "pointerSymbol": "@",
+          "synsetOffset": 5798043,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "meta": {
+              "synsetOffset": 5798043,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 2,
+              "words": [
+                { "word": "experiment", "lexId": 0 },
+                { "word": "experimentation", "lexId": 0 }
+              ],
+              "pointerCount": 6,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5797597,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2532886,
+                  "pos": "v",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2532595,
+                  "pos": "v",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2532595,
+                  "pos": "v",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5799071,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            },
+            "glossary": "the testing of an idea; \"it was an experiment in living\"; \"not all experimentation is done in laboratories\""
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 2531625,
+          "pos": "v",
+          "sourceTargetHex": "0404",
+          "data": {
+            "meta": {
+              "synsetOffset": 2531625,
+              "lexFilenum": 41,
+              "synsetType": "verb",
+              "wordCount": 6,
+              "words": [
+                { "word": "test", "lexId": 0 },
+                { "word": "prove", "lexId": 3 },
+                { "word": "try", "lexId": 1 },
+                { "word": "try_out", "lexId": 0 },
+                { "word": "examine", "lexId": 0 },
+                { "word": "essay", "lexId": 1 }
+              ],
+              "pointerCount": 13,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 670261,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 7197021,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5787005,
+                  "pos": "n",
+                  "sourceTargetHex": "0502"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 636461,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10068234,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0404"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10728998,
+                  "pos": "n",
+                  "sourceTargetHex": "0301"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 794367,
+                  "pos": "n",
+                  "sourceTargetHex": "0302"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0103"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 639975,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2520997,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2532079,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2532261,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            },
+            "glossary": "put to the test, as for its quality, or give experimental use to; \"This approach has been tried with good results\"; \"Test this recipe\""
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 1195299,
+          "pos": "v",
+          "sourceTargetHex": "0403",
+          "data": {
+            "meta": {
+              "synsetOffset": 1195299,
+              "lexFilenum": 34,
+              "synsetType": "verb",
+              "wordCount": 4,
+              "words": [
+                { "word": "sample", "lexId": 0 },
+                { "word": "try", "lexId": 0 },
+                { "word": "try_out", "lexId": 0 },
+                { "word": "taste", "lexId": 0 }
+              ],
+              "pointerCount": 13,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 1156834,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 7578879,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10692482,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5822612,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 841901,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0304"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10728998,
+                  "pos": "n",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5821775,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10692482,
+                  "pos": "n",
+                  "sourceTargetHex": "0104"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 8463817,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 4133211,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 1195675,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            },
+            "glossary": "take a sample of; \"Try these new crackers\"; \"Sample the regional dishes\""
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 2531625,
+          "pos": "v",
+          "sourceTargetHex": "0301",
+          "data": {
+            "meta": {
+              "synsetOffset": 2531625,
+              "lexFilenum": 41,
+              "synsetType": "verb",
+              "wordCount": 6,
+              "words": [
+                { "word": "test", "lexId": 0 },
+                { "word": "prove", "lexId": 3 },
+                { "word": "try", "lexId": 1 },
+                { "word": "try_out", "lexId": 0 },
+                { "word": "examine", "lexId": 0 },
+                { "word": "essay", "lexId": 1 }
+              ],
+              "pointerCount": 13,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 670261,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 7197021,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5787005,
+                  "pos": "n",
+                  "sourceTargetHex": "0502"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 636461,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10068234,
+                  "pos": "n",
+                  "sourceTargetHex": "0501"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0404"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10728998,
+                  "pos": "n",
+                  "sourceTargetHex": "0301"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 794367,
+                  "pos": "n",
+                  "sourceTargetHex": "0302"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0103"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 639975,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2520997,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2532079,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 2532261,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            },
+            "glossary": "put to the test, as for its quality, or give experimental use to; \"This approach has been tried with good results\"; \"Test this recipe\""
+          }
+        },
+        {
+          "pointerSymbol": "+",
+          "synsetOffset": 1195299,
+          "pos": "v",
+          "sourceTargetHex": "0102",
+          "data": {
+            "meta": {
+              "synsetOffset": 1195299,
+              "lexFilenum": 34,
+              "synsetType": "verb",
+              "wordCount": 4,
+              "words": [
+                { "word": "sample", "lexId": 0 },
+                { "word": "try", "lexId": 0 },
+                { "word": "try_out", "lexId": 0 },
+                { "word": "taste", "lexId": 0 }
+              ],
+              "pointerCount": 13,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 1156834,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 7578879,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10692482,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5822612,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 841901,
+                  "pos": "n",
+                  "sourceTargetHex": "0401"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0304"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10728998,
+                  "pos": "n",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0201"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 5821775,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 10692482,
+                  "pos": "n",
+                  "sourceTargetHex": "0104"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 8463817,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 4133211,
+                  "pos": "n",
+                  "sourceTargetHex": "0101"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 1195675,
+                  "pos": "v",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            },
+            "glossary": "take a sample of; \"Try these new crackers\"; \"Sample the regional dishes\""
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 5799581,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "meta": {
+              "synsetOffset": 5799581,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 2,
+              "words": [
+                { "word": "field_trial", "lexId": 0 },
+                { "word": "field_test", "lexId": 0 }
+              ],
+              "pointerCount": 2,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "+",
+                  "synsetOffset": 2532261,
+                  "pos": "v",
+                  "sourceTargetHex": "0201"
+                }
+              ]
+            },
+            "glossary": "a test of the performance of some new product under the conditions in which it will be used"
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 5799761,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "meta": {
+              "synsetOffset": 5799761,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 1,
+              "words": [ { "word": "alpha_test", "lexId": 0 } ],
+              "pointerCount": 2,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": ";c",
+                  "synsetOffset": 3082979,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            },
+            "glossary": "(computer science) a first test of an experimental product (such as computer software) carried out by the developer"
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 5799952,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "meta": {
+              "synsetOffset": 5799952,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 1,
+              "words": [ { "word": "beta_test", "lexId": 0 } ],
+              "pointerCount": 2,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": ";c",
+                  "synsetOffset": 3082979,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            },
+            "glossary": "(computer science) a second test of an experimental product (such as computer software) carried out by an outside organization"
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 5800153,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "meta": {
+              "synsetOffset": 5800153,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 1,
+              "words": [ { "word": "road_test", "lexId": 0 } ],
+              "pointerCount": 2,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                },
+                {
+                  "pointerSymbol": "~",
+                  "synsetOffset": 5800387,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            },
+            "glossary": "a test to insure that a vehicle is roadworthy"
+          }
+        },
+        {
+          "pointerSymbol": "~",
+          "synsetOffset": 5800527,
+          "pos": "n",
+          "sourceTargetHex": "0000",
+          "data": {
+            "meta": {
+              "synsetOffset": 5800527,
+              "lexFilenum": 9,
+              "synsetType": "noun",
+              "wordCount": 1,
+              "words": [ { "word": "trial_balloon", "lexId": 0 } ],
+              "pointerCount": 1,
+              "pointers": [
+                {
+                  "pointerSymbol": "@",
+                  "synsetOffset": 5799212,
+                  "pos": "n",
+                  "sourceTargetHex": "0000"
+                }
+              ]
+            },
+            "glossary": "a test of public opinion"
+          }
+        }
+      ]
+    },
+    "glossary": "trying something to find out about it; \"a sample for ten days free trial\"; \"a trial of progesterone failed to relieve the pain\""
+  },
+  {
     "meta": {
       "synsetOffset": 2531625,
       "lexFilenum": 41,
@@ -22,7 +661,6 @@
           "pos": "v",
           "sourceTargetHex": "0000",
           "data": {
-            "glossary": "form a critical opinion of; \"I cannot judge some works of modern art\"; \"How do you evaluate this grant proposal?\" \"We shouldn't pass judgment on other people\"",
             "meta": {
               "synsetOffset": 670261,
               "lexFilenum": 31,
@@ -192,7 +830,8 @@
                   "sourceTargetHex": "0000"
                 }
               ]
-            }
+            },
+            "glossary": "form a critical opinion of; \"I cannot judge some works of modern art\"; \"How do you evaluate this grant proposal?\" \"We shouldn't pass judgment on other people\""
           }
         },
         {
@@ -201,7 +840,6 @@
           "pos": "n",
           "sourceTargetHex": "0501",
           "data": {
-            "glossary": "a set of questions or exercises evaluating skill or knowledge; \"when the test was stolen the professor had to make a new set of questions\"",
             "meta": {
               "synsetOffset": 7197021,
               "lexFilenum": 10,
@@ -323,7 +961,8 @@
                   "sourceTargetHex": "0000"
                 }
               ]
-            }
+            },
+            "glossary": "a set of questions or exercises evaluating skill or knowledge; \"when the test was stolen the professor had to make a new set of questions\""
           }
         },
         {
@@ -332,7 +971,6 @@
           "pos": "n",
           "sourceTargetHex": "0502",
           "data": {
-            "glossary": "a detailed inspection of your conscience (as done daily by Jesuits)",
             "meta": {
               "synsetOffset": 5787005,
               "lexFilenum": 9,
@@ -363,7 +1001,8 @@
                   "sourceTargetHex": "0204"
                 }
               ]
-            }
+            },
+            "glossary": "a detailed inspection of your conscience (as done daily by Jesuits)"
           }
         },
         {
@@ -372,7 +1011,6 @@
           "pos": "n",
           "sourceTargetHex": "0501",
           "data": {
-            "glossary": "the act of giving students or candidates a test (as by questions) to determine what they know or have learned",
             "meta": {
               "synsetOffset": 636461,
               "lexFilenum": 4,
@@ -421,7 +1059,8 @@
                   "sourceTargetHex": "0000"
                 }
               ]
-            }
+            },
+            "glossary": "the act of giving students or candidates a test (as by questions) to determine what they know or have learned"
           }
         },
         {
@@ -430,7 +1069,6 @@
           "pos": "n",
           "sourceTargetHex": "0501",
           "data": {
-            "glossary": "someone who administers a test to determine your qualifications",
             "meta": {
               "synsetOffset": 10068234,
               "lexFilenum": 18,
@@ -468,7 +1106,8 @@
                   "sourceTargetHex": "0105"
                 }
               ]
-            }
+            },
+            "glossary": "someone who administers a test to determine your qualifications"
           }
         },
         {
@@ -477,7 +1116,6 @@
           "pos": "n",
           "sourceTargetHex": "0404",
           "data": {
-            "glossary": "trying something to find out about it; \"a sample for ten days free trial\"; \"a trial of progesterone failed to relieve the pain\"",
             "meta": {
               "synsetOffset": 5799212,
               "lexFilenum": 9,
@@ -552,7 +1190,8 @@
                   "sourceTargetHex": "0000"
                 }
               ]
-            }
+            },
+            "glossary": "trying something to find out about it; \"a sample for ten days free trial\"; \"a trial of progesterone failed to relieve the pain\""
           }
         },
         {
@@ -561,7 +1200,6 @@
           "pos": "n",
           "sourceTargetHex": "0301",
           "data": {
-            "glossary": "one who tries",
             "meta": {
               "synsetOffset": 10728998,
               "lexFilenum": 18,
@@ -611,7 +1249,8 @@
                   "sourceTargetHex": "0102"
                 }
               ]
-            }
+            },
+            "glossary": "one who tries"
           }
         },
         {
@@ -620,7 +1259,6 @@
           "pos": "n",
           "sourceTargetHex": "0302",
           "data": {
-            "glossary": "the act of undergoing testing; \"he survived the great test of battle\"; \"candidates must compete in a trial of skill\"",
             "meta": {
               "synsetOffset": 794367,
               "lexFilenum": 4,
@@ -660,7 +1298,8 @@
                   "sourceTargetHex": "0102"
                 }
               ]
-            }
+            },
+            "glossary": "the act of undergoing testing; \"he survived the great test of battle\"; \"candidates must compete in a trial of skill\""
           }
         },
         {
@@ -669,7 +1308,6 @@
           "pos": "n",
           "sourceTargetHex": "0103",
           "data": {
-            "glossary": "trying something to find out about it; \"a sample for ten days free trial\"; \"a trial of progesterone failed to relieve the pain\"",
             "meta": {
               "synsetOffset": 5799212,
               "lexFilenum": 9,
@@ -744,7 +1382,8 @@
                   "sourceTargetHex": "0000"
                 }
               ]
-            }
+            },
+            "glossary": "trying something to find out about it; \"a sample for ten days free trial\"; \"a trial of progesterone failed to relieve the pain\""
           }
         },
         {
@@ -753,7 +1392,6 @@
           "pos": "n",
           "sourceTargetHex": "0101",
           "data": {
-            "glossary": "the act of subjecting to experimental test in order to determine how well something works; \"they agreed to end the testing of atomic weapons\"",
             "meta": {
               "synsetOffset": 639975,
               "lexFilenum": 4,
@@ -775,7 +1413,8 @@
                   "sourceTargetHex": "0101"
                 }
               ]
-            }
+            },
+            "glossary": "the act of subjecting to experimental test in order to determine how well something works; \"they agreed to end the testing of atomic weapons\""
           }
         },
         {
@@ -784,7 +1423,6 @@
           "pos": "v",
           "sourceTargetHex": "0000",
           "data": {
-            "glossary": "check or regulate (a scientific experiment) by conducting a parallel experiment or comparing with another standard; \"Are you controlling for the temperature?\"",
             "meta": {
               "synsetOffset": 2520997,
               "lexFilenum": 41,
@@ -821,7 +1459,8 @@
                   "sourceTargetHex": "0102"
                 }
               ]
-            }
+            },
+            "glossary": "check or regulate (a scientific experiment) by conducting a parallel experiment or comparing with another standard; \"Are you controlling for the temperature?\""
           }
         },
         {
@@ -830,7 +1469,6 @@
           "pos": "v",
           "sourceTargetHex": "0000",
           "data": {
-            "glossary": "circulate or discuss tentatively; test the waters with; \"The Republicans are floating the idea of a tax reform\"",
             "meta": {
               "synsetOffset": 2532079,
               "lexFilenum": 41,
@@ -846,7 +1484,8 @@
                   "sourceTargetHex": "0000"
                 }
               ]
-            }
+            },
+            "glossary": "circulate or discuss tentatively; test the waters with; \"The Republicans are floating the idea of a tax reform\""
           }
         },
         {
@@ -855,7 +1494,6 @@
           "pos": "v",
           "sourceTargetHex": "0000",
           "data": {
-            "glossary": "test something under the conditions under which it will actually be used; \"The Army field tested the new tanks\"",
             "meta": {
               "synsetOffset": 2532261,
               "lexFilenum": 41,
@@ -877,650 +1515,12 @@
                   "sourceTargetHex": "0102"
                 }
               ]
-            }
+            },
+            "glossary": "test something under the conditions under which it will actually be used; \"The Army field tested the new tanks\""
           }
         }
       ]
-    }
-  },
-  {
-    "glossary": "trying something to find out about it; \"a sample for ten days free trial\"; \"a trial of progesterone failed to relieve the pain\"",
-    "meta": {
-      "synsetOffset": 5799212,
-      "lexFilenum": 9,
-      "synsetType": "noun",
-      "wordCount": 4,
-      "words": [
-        { "word": "trial", "lexId": 0 },
-        { "word": "trial_run", "lexId": 0 },
-        { "word": "test", "lexId": 2 },
-        { "word": "tryout", "lexId": 0 }
-      ],
-      "pointerCount": 10,
-      "pointers": [
-        {
-          "pointerSymbol": "@",
-          "synsetOffset": 5798043,
-          "pos": "n",
-          "sourceTargetHex": "0000",
-          "data": {
-            "glossary": "the testing of an idea; \"it was an experiment in living\"; \"not all experimentation is done in laboratories\"",
-            "meta": {
-              "synsetOffset": 5798043,
-              "lexFilenum": 9,
-              "synsetType": "noun",
-              "wordCount": 2,
-              "words": [
-                { "word": "experiment", "lexId": 0 },
-                { "word": "experimentation", "lexId": 0 }
-              ],
-              "pointerCount": 6,
-              "pointers": [
-                {
-                  "pointerSymbol": "@",
-                  "synsetOffset": 5797597,
-                  "pos": "n",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 2532886,
-                  "pos": "v",
-                  "sourceTargetHex": "0201"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 2532595,
-                  "pos": "v",
-                  "sourceTargetHex": "0201"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 2532595,
-                  "pos": "v",
-                  "sourceTargetHex": "0101"
-                },
-                {
-                  "pointerSymbol": "~",
-                  "synsetOffset": 5799071,
-                  "pos": "n",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "~",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0000"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "pointerSymbol": "+",
-          "synsetOffset": 2531625,
-          "pos": "v",
-          "sourceTargetHex": "0404",
-          "data": {
-            "glossary": "put to the test, as for its quality, or give experimental use to; \"This approach has been tried with good results\"; \"Test this recipe\"",
-            "meta": {
-              "synsetOffset": 2531625,
-              "lexFilenum": 41,
-              "synsetType": "verb",
-              "wordCount": 6,
-              "words": [
-                { "word": "test", "lexId": 0 },
-                { "word": "prove", "lexId": 3 },
-                { "word": "try", "lexId": 1 },
-                { "word": "try_out", "lexId": 0 },
-                { "word": "examine", "lexId": 0 },
-                { "word": "essay", "lexId": 1 }
-              ],
-              "pointerCount": 13,
-              "pointers": [
-                {
-                  "pointerSymbol": "@",
-                  "synsetOffset": 670261,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 7197021,
-                  "pos": "n",
-                  "sourceTargetHex": "0501"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5787005,
-                  "pos": "n",
-                  "sourceTargetHex": "0502"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 636461,
-                  "pos": "n",
-                  "sourceTargetHex": "0501"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 10068234,
-                  "pos": "n",
-                  "sourceTargetHex": "0501"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0404"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 10728998,
-                  "pos": "n",
-                  "sourceTargetHex": "0301"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 794367,
-                  "pos": "n",
-                  "sourceTargetHex": "0302"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0103"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 639975,
-                  "pos": "n",
-                  "sourceTargetHex": "0101"
-                },
-                {
-                  "pointerSymbol": "~",
-                  "synsetOffset": 2520997,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "~",
-                  "synsetOffset": 2532079,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "~",
-                  "synsetOffset": 2532261,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "pointerSymbol": "+",
-          "synsetOffset": 1195299,
-          "pos": "v",
-          "sourceTargetHex": "0403",
-          "data": {
-            "glossary": "take a sample of; \"Try these new crackers\"; \"Sample the regional dishes\"",
-            "meta": {
-              "synsetOffset": 1195299,
-              "lexFilenum": 34,
-              "synsetType": "verb",
-              "wordCount": 4,
-              "words": [
-                { "word": "sample", "lexId": 0 },
-                { "word": "try", "lexId": 0 },
-                { "word": "try_out", "lexId": 0 },
-                { "word": "taste", "lexId": 0 }
-              ],
-              "pointerCount": 13,
-              "pointers": [
-                {
-                  "pointerSymbol": "@",
-                  "synsetOffset": 1156834,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 7578879,
-                  "pos": "n",
-                  "sourceTargetHex": "0401"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 10692482,
-                  "pos": "n",
-                  "sourceTargetHex": "0401"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5822612,
-                  "pos": "n",
-                  "sourceTargetHex": "0401"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 841901,
-                  "pos": "n",
-                  "sourceTargetHex": "0401"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0304"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 10728998,
-                  "pos": "n",
-                  "sourceTargetHex": "0201"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0201"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5821775,
-                  "pos": "n",
-                  "sourceTargetHex": "0101"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 10692482,
-                  "pos": "n",
-                  "sourceTargetHex": "0104"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 8463817,
-                  "pos": "n",
-                  "sourceTargetHex": "0101"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 4133211,
-                  "pos": "n",
-                  "sourceTargetHex": "0101"
-                },
-                {
-                  "pointerSymbol": "~",
-                  "synsetOffset": 1195675,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "pointerSymbol": "+",
-          "synsetOffset": 2531625,
-          "pos": "v",
-          "sourceTargetHex": "0301",
-          "data": {
-            "glossary": "put to the test, as for its quality, or give experimental use to; \"This approach has been tried with good results\"; \"Test this recipe\"",
-            "meta": {
-              "synsetOffset": 2531625,
-              "lexFilenum": 41,
-              "synsetType": "verb",
-              "wordCount": 6,
-              "words": [
-                { "word": "test", "lexId": 0 },
-                { "word": "prove", "lexId": 3 },
-                { "word": "try", "lexId": 1 },
-                { "word": "try_out", "lexId": 0 },
-                { "word": "examine", "lexId": 0 },
-                { "word": "essay", "lexId": 1 }
-              ],
-              "pointerCount": 13,
-              "pointers": [
-                {
-                  "pointerSymbol": "@",
-                  "synsetOffset": 670261,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 7197021,
-                  "pos": "n",
-                  "sourceTargetHex": "0501"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5787005,
-                  "pos": "n",
-                  "sourceTargetHex": "0502"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 636461,
-                  "pos": "n",
-                  "sourceTargetHex": "0501"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 10068234,
-                  "pos": "n",
-                  "sourceTargetHex": "0501"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0404"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 10728998,
-                  "pos": "n",
-                  "sourceTargetHex": "0301"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 794367,
-                  "pos": "n",
-                  "sourceTargetHex": "0302"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0103"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 639975,
-                  "pos": "n",
-                  "sourceTargetHex": "0101"
-                },
-                {
-                  "pointerSymbol": "~",
-                  "synsetOffset": 2520997,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "~",
-                  "synsetOffset": 2532079,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "~",
-                  "synsetOffset": 2532261,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "pointerSymbol": "+",
-          "synsetOffset": 1195299,
-          "pos": "v",
-          "sourceTargetHex": "0102",
-          "data": {
-            "glossary": "take a sample of; \"Try these new crackers\"; \"Sample the regional dishes\"",
-            "meta": {
-              "synsetOffset": 1195299,
-              "lexFilenum": 34,
-              "synsetType": "verb",
-              "wordCount": 4,
-              "words": [
-                { "word": "sample", "lexId": 0 },
-                { "word": "try", "lexId": 0 },
-                { "word": "try_out", "lexId": 0 },
-                { "word": "taste", "lexId": 0 }
-              ],
-              "pointerCount": 13,
-              "pointers": [
-                {
-                  "pointerSymbol": "@",
-                  "synsetOffset": 1156834,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 7578879,
-                  "pos": "n",
-                  "sourceTargetHex": "0401"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 10692482,
-                  "pos": "n",
-                  "sourceTargetHex": "0401"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5822612,
-                  "pos": "n",
-                  "sourceTargetHex": "0401"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 841901,
-                  "pos": "n",
-                  "sourceTargetHex": "0401"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0304"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 10728998,
-                  "pos": "n",
-                  "sourceTargetHex": "0201"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0201"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 5821775,
-                  "pos": "n",
-                  "sourceTargetHex": "0101"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 10692482,
-                  "pos": "n",
-                  "sourceTargetHex": "0104"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 8463817,
-                  "pos": "n",
-                  "sourceTargetHex": "0101"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 4133211,
-                  "pos": "n",
-                  "sourceTargetHex": "0101"
-                },
-                {
-                  "pointerSymbol": "~",
-                  "synsetOffset": 1195675,
-                  "pos": "v",
-                  "sourceTargetHex": "0000"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "pointerSymbol": "~",
-          "synsetOffset": 5799581,
-          "pos": "n",
-          "sourceTargetHex": "0000",
-          "data": {
-            "glossary": "a test of the performance of some new product under the conditions in which it will be used",
-            "meta": {
-              "synsetOffset": 5799581,
-              "lexFilenum": 9,
-              "synsetType": "noun",
-              "wordCount": 2,
-              "words": [
-                { "word": "field_trial", "lexId": 0 },
-                { "word": "field_test", "lexId": 0 }
-              ],
-              "pointerCount": 2,
-              "pointers": [
-                {
-                  "pointerSymbol": "@",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "+",
-                  "synsetOffset": 2532261,
-                  "pos": "v",
-                  "sourceTargetHex": "0201"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "pointerSymbol": "~",
-          "synsetOffset": 5799761,
-          "pos": "n",
-          "sourceTargetHex": "0000",
-          "data": {
-            "glossary": "(computer science) a first test of an experimental product (such as computer software) carried out by the developer",
-            "meta": {
-              "synsetOffset": 5799761,
-              "lexFilenum": 9,
-              "synsetType": "noun",
-              "wordCount": 1,
-              "words": [ { "word": "alpha_test", "lexId": 0 } ],
-              "pointerCount": 2,
-              "pointers": [
-                {
-                  "pointerSymbol": "@",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": ";c",
-                  "synsetOffset": 3082979,
-                  "pos": "n",
-                  "sourceTargetHex": "0000"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "pointerSymbol": "~",
-          "synsetOffset": 5799952,
-          "pos": "n",
-          "sourceTargetHex": "0000",
-          "data": {
-            "glossary": "(computer science) a second test of an experimental product (such as computer software) carried out by an outside organization",
-            "meta": {
-              "synsetOffset": 5799952,
-              "lexFilenum": 9,
-              "synsetType": "noun",
-              "wordCount": 1,
-              "words": [ { "word": "beta_test", "lexId": 0 } ],
-              "pointerCount": 2,
-              "pointers": [
-                {
-                  "pointerSymbol": "@",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": ";c",
-                  "synsetOffset": 3082979,
-                  "pos": "n",
-                  "sourceTargetHex": "0000"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "pointerSymbol": "~",
-          "synsetOffset": 5800153,
-          "pos": "n",
-          "sourceTargetHex": "0000",
-          "data": {
-            "glossary": "a test to insure that a vehicle is roadworthy",
-            "meta": {
-              "synsetOffset": 5800153,
-              "lexFilenum": 9,
-              "synsetType": "noun",
-              "wordCount": 1,
-              "words": [ { "word": "road_test", "lexId": 0 } ],
-              "pointerCount": 2,
-              "pointers": [
-                {
-                  "pointerSymbol": "@",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0000"
-                },
-                {
-                  "pointerSymbol": "~",
-                  "synsetOffset": 5800387,
-                  "pos": "n",
-                  "sourceTargetHex": "0000"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "pointerSymbol": "~",
-          "synsetOffset": 5800527,
-          "pos": "n",
-          "sourceTargetHex": "0000",
-          "data": {
-            "glossary": "a test of public opinion",
-            "meta": {
-              "synsetOffset": 5800527,
-              "lexFilenum": 9,
-              "synsetType": "noun",
-              "wordCount": 1,
-              "words": [ { "word": "trial_balloon", "lexId": 0 } ],
-              "pointerCount": 1,
-              "pointers": [
-                {
-                  "pointerSymbol": "@",
-                  "synsetOffset": 5799212,
-                  "pos": "n",
-                  "sourceTargetHex": "0000"
-                }
-              ]
-            }
-          }
-        }
-      ]
-    }
+    },
+    "glossary": "put to the test, as for its quality, or give experimental use to; \"This approach has been tried with good results\"; \"Test this recipe\""
   }]
 }

--- a/test/wordnet.js
+++ b/test/wordnet.js
@@ -1,0 +1,27 @@
+let test = require('tape');
+let wordnet = require('../lib/wordnet');
+let fixture = require('./fixture.json')
+
+test('api', async (t) => {
+  t.plan(6);
+  const WORD = 'test';
+  const expected = fixture[WORD];
+
+  // TODO: Add tests for expected failure cases:
+  // - Calling API functions before init.
+  // - Searching for a word not in the database.
+
+  await wordnet.init();
+
+  let list = await wordnet.list();
+  t.equal(list.length, 147306, "Check database size.");
+
+  let definitions = await wordnet.lookup(WORD);
+
+  t.equal(definitions.length, expected.length, "Check number of definitions.");
+
+  definitions.forEach((definition, index) => {
+    t.equal(definition.glossary, expected[index].glossary, "Check definitions match.");
+    t.deepEqual(definition.meta, expected[index].meta, "Check meta matches.");
+  });
+});


### PR DESCRIPTION
Hi there 👋 .

Admittedly I got a little carried away with this, but I was hoping to use this library and thought it could use some improvements, namely updating it to use promises.

I've included tests and (loosely) verified that it passes with the existing codebase, though the API change is breaking. I made a branch [for just tests](https://github.com/words/wordnet/compare/master...hijonathan:tests) and can merge that first if you'd like. I also used `tape` since that seems to be what you use in other repos.

Sorry for the big PR. I tried to make as few changes as possible, but since everything seems to use callbacks it was unavoidable.